### PR TITLE
Newest popular

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,4 +2,8 @@ class TopController < ApplicationController
   def index
     @prototypes = Prototype.all.page(params[:page]).eager_load(:prototype_images, :user)
   end
+
+  def newest
+    @prototypes = Prototype.order(created_at: :desc).page(params[:page]).eager_load(:prototype_images, :user)
+  end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,6 +1,6 @@
 class TopController < ApplicationController
   def index
-    @prototypes = Prototype.all.page(params[:page]).eager_load(:prototype_images, :user)
+    @prototypes = Prototype.order(likes_count: :desc).page(params[:page]).eager_load(:prototype_images, :user)
   end
 
   def newest

--- a/app/views/top/newest.html.haml
+++ b/app/views/top/newest.html.haml
@@ -11,10 +11,10 @@
   .container
     .row
       %ul.nav.nav-pills.col-lg-11
-        %li.active{:role => "presentation"}
-          = link_to "Popular PROTO", root_path
         %li{:role => "presentation"}
-          = link_to "Newest PROTO", newest_path
+          = link_to "Popular PROTO",root_path
+        %li.active{:role => "presentation"}
+          = link_to "Newest PROTO",newest_path
       %button{:type => "button", :class => "btn btn-default col-lg-1"} View Tags
 .container.proto-list
   .row

--- a/app/views/top/newest.html.haml
+++ b/app/views/top/newest.html.haml
@@ -12,9 +12,9 @@
     .row
       %ul.nav.nav-pills.col-lg-11
         %li{:role => "presentation"}
-          = link_to "Popular PROTO",root_path
+          = link_to "Popular PROTO", root_path
         %li.active{:role => "presentation"}
-          = link_to "Newest PROTO",newest_path
+          = link_to "Newest PROTO", newest_path
       %button{:type => "button", :class => "btn btn-default col-lg-1"} View Tags
 .container.proto-list
   .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
   root 'top#index'
+  get 'newest' => 'top#newest', as: 'newest'
   post 'like/:prototype_id' => 'likes#create', as: 'like'
   delete 'like/:prototype_id' => 'likes#destroy', as: 'destroy_like'
 


### PR DESCRIPTION
# WHAT
- トップページのprototype一覧をlike数順でソート(popular)した。
- newestアクションをtopコントローラに追加し、prototype一覧を投稿日時でソート(newest)可能にした。また、表示用のビューを作成した。
# WHY
-  トップページにて最新、人気のプロトタイプを表示するため。
